### PR TITLE
Update fixtures.py

### DIFF
--- a/pytest_click/fixtures.py
+++ b/pytest_click/fixtures.py
@@ -13,7 +13,7 @@ def cli_runner(request):
         ...
     """
     init_kwargs = {}
-    marker = request.node.get_marker('runner_setup')
+    marker = request.node.get_closest_marker('runner_setup')
     if marker:
         init_kwargs = marker.kwargs
     return CliRunner(**init_kwargs)


### PR DESCRIPTION
```
E           _pytest.warning_types.RemovedInPytest4Warning: MarkInfo objects are deprecated as they contain merged marks which are hard to deal with correctly.
E           Please use node.get_closest_marker(name) or node.iter_markers(name).
E           Docs: https://docs.pytest.org/en/latest/mark.html#updating-code
```