### PR TITLE
Drop support for python3.5 and 3.6, add support for 3.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python: [3.5, 3.6, 3.7, 3.8, 3.9.0-rc.1, pypy3]
+        python: [3.7, 3.8, 3.9, pypy3]
 
     name: ${{ matrix.os }}/tests_${{ matrix.python }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - run: pip install pre-commit
       - run: SKIP=pylint pre-commit run --all-files
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - run: pip install pre-commit
       - run: pre-commit run pylint --all-files
@@ -58,7 +58,7 @@ jobs:
 
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - run: pip install pre-commit
       - run: pre-commit run mypy --all-files

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python: [3.7, 3.8, 3.9, 3.10, pypy3]
+        python: ['3.7', '3.8', '3.9', '3.10', 'pypy3']
 
     name: ${{ matrix.os }}/tests_${{ matrix.python }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python: [3.7, 3.8, 3.9, pypy3]
+        python: [3.7, 3.8, 3.9, 3.10, pypy3]
 
     name: ${{ matrix.os }}/tests_${{ matrix.python }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,13 @@ on:
 jobs:
   build-n-publish:
     name: Build and publish Python 🐍distributions 📦 to PyPI
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@master
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
     - name: Install tox
       run: >-
         python -m

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 default_language_version:
-  python: python3.7
+  python: python3.8
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.1.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -15,17 +15,17 @@ repos:
       - id: check-merge-conflict
 
   - repo: https://github.com/jorisroovers/gitlint
-    rev: v0.13.1
+    rev: v0.17.0
     hooks:
       - id: gitlint
 
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.23.0
+    rev: v1.26.3
     hooks:
       - id: yamllint
 
   - repo: https://github.com/PyCQA/pydocstyle
-    rev: 5.1.0
+    rev: 6.1.1
     hooks:
       - id: pydocstyle
 
@@ -35,7 +35,7 @@ repos:
       - id: relint
 
   - repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: 22.1.0
     hooks:
       - id: black
         types: [python]
@@ -46,20 +46,20 @@ repos:
       - id: seed-isort-config
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.782
+    rev: v0.931
     hooks:
       - id: mypy
         exclude: ^(docs/|test/|setup.py).*$
         args: ["--ignore-missing-imports"]
 
   - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.4.2
+    rev: v5.10.1
     hooks:
       - id: isort
         additional_dependencies: ["isort[pyproject]"]
 
   - repo: https://github.com/pre-commit/mirrors-pylint
-    rev: v2.6.0
+    rev: v3.0.0a4
     hooks:
       - id: pylint
         additional_dependencies: ["isort[pyproject]"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 History
 -------
 
+- Added build for Python 3.10
+- Drop support of Python 3.5 & 3.6
+
 1.0.2 - 29.08.2020
 ----------------
 

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,6 @@ setup(
         "Operating System :: OS Independent",
         "License :: OSI Approved :: MIT License",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Testing",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = py{36,37,38,39,py3}, coverage-report
+envlist = py{37,38,39,py3}, coverage-report
 
 [testenv]
 setenv =
@@ -19,7 +19,7 @@ description = Report coverage over all measured test runs.
 basepython = python3.8
 deps = coverage
 skip_install = true
-depends = py{36,37,38,39}
+depends = py{37,38,39}
 commands =
     coverage combine
     coverage report

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 isolated_build = true
-envlist = py{37,38,39,py3}, coverage-report
+envlist = py{37,38,39,310,py3}, coverage-report
 
 [testenv]
 setenv =
@@ -19,7 +19,7 @@ description = Report coverage over all measured test runs.
 basepython = python3.8
 deps = coverage
 skip_install = true
-depends = py{37,38,39}
+depends = py{37,38,39,310}
 commands =
     coverage combine
     coverage report


### PR DESCRIPTION
@Stranger6667, since you were kind enough to respond to my previous, unintended pull request, I won't open an issue first.
You've also mentioned to add a CHANGELOG entry, please let me know what version you would like to use (I expect 1.1.0 since it drops support for some python versions). Should I also update the version in setup.py, in this case? Should I add today's date? Your repo, your rules, hence the many questions :)

Thanks!
